### PR TITLE
Fix LinkedIn Profile Link Redirection (Closes #331)

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
               <i class="socialIcons fab fa-github fa-3x link1"></i>
           </li>
           <li>
-            <a href="https://www.linkedin.com/in/avinash-singh-071b79175/" target="_blank">
+            <a href="https://www.linkedin.com/in/avinash-singh-bb0b8a371/" target="_blank">
               <i class="fab fa-linkedin-in fa-3x link2"></i>
           </li>
           <li>


### PR DESCRIPTION
#### Description
This PR addresses Issue #331 by resolving the broken LinkedIn profile link. The link now correctly redirects to the intended LinkedIn profile URL, ensuring seamless navigation for users.

**Changes Made:**  
- Updated the hardcoded LinkedIn URL in the profile component
- Ensured the link opens in a new tab (using `target="_blank"`) for better user experience.  
- Tested across multiple browsers to confirm compatibility.

**Why This Fix?**  
The original link was pointing to an invalid endpoint, causing navigation failures. This update restores full functionality and improves reliability for professional networking features.

**Testing Instructions:**  
1. Navigate to the bottom of the page.
2. Click the LinkedIn profile link.  
3. Verify it redirects to the correct LinkedIn profile (e.g., no 404 error, proper URL loaded).  
4. Test in different browsers (Chrome, Firefox, Safari) and devices (desktop, mobile).  

**Video:**

https://github.com/user-attachments/assets/1ecb4638-7b52-49b7-81b9-9ba1351a77f6



Closes #331
