### PR TITLE
Add interactive Satellite Map with auto-zoom to searched city

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Check out the live version of the app here → [**Weather App**](https://avinash
 
 ✅ Clean and beginner-friendly JavaScript code
 
+✅ NEW: Interactive city map under the search bar (Leaflet + Esri World Imagery) that auto-centers, zooms, and drops a marker for the searched/geolocated city
+
 
 ## 🧩 Tech Stack
 
@@ -58,3 +60,4 @@ Interested in contributing? Check out the [Contribution Guide](https://github.co
 
 For any queries or collaborations, connect with me on [**LinkedIn**](https://www.linkedin.com/in/avinash-singh-071b79175) — always happy to chat! 🤝  
 
+---

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -87,7 +87,8 @@
       inset 0 0 8px 4px rgba(255, 255, 255, 0.4);
     position: relative;
     overflow: hidden;
-    width: 400px;
+    width: 100%;
+    max-width: 840px;
     height: auto;
 }
 
@@ -602,6 +603,36 @@ figure.weather-component__icn {
     background: rgba(255, 255, 255, 0.05);
     border-radius: 10px;
 }
+
+/* Map styles */
+.map-box {
+  position: relative;
+  width: 100%;
+  margin: 12px 0 16px 0;
+}
+#weather-map {
+  width: 100%;
+  height: 360px;
+  min-height: 360px;
+  border-radius: 16px;
+  overflow: hidden;
+}
+#weather-map .leaflet-container,
+.leaflet-container {
+  background: #000 !important; /* match app tone while tiles load */
+}
+.map-header {
+  position: absolute;
+  top: -14px;
+  left: 12px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.35);
+  padding: 6px 12px;
+  border-radius: 12px;
+  backdrop-filter: blur(8px);
+}
+/* Hide default Leaflet attribution */
+.leaflet-control-attribution { display: none !important; }
 
 /* Responsive Design for new features */
 @media (max-width: 768px) {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -284,6 +284,52 @@ $(".checkbox").change(function () {
   weather.fetchWeather(selectedCity);
 });
 
+// Leaflet map integration (Esri World Imagery)
+let _weatherMap = null;
+let _weatherMapMarker = null;
+function initLeafletMap() {
+  if (_weatherMap) return;
+  const el = document.getElementById('weather-map');
+  if (!el || typeof L === 'undefined') return;
+  _weatherMap = L.map('weather-map', {
+    zoomControl: true,
+    attributionControl: false,
+    scrollWheelZoom: true
+  });
+  // Ensure the map renders immediately
+  _weatherMap.setView([20, 0], 2);
+  const primaryUrl = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+  const fallbackUrl = 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+  const layer = L.tileLayer(primaryUrl, { maxZoom: 19 }).addTo(_weatherMap);
+  layer.on('tileerror', () => {
+    // If a tile fails, swap to fallback endpoint once
+    if (!_weatherMap.__esriFallback) {
+      _weatherMap.__esriFallback = true;
+      L.tileLayer(fallbackUrl, { maxZoom: 19 }).addTo(_weatherMap);
+    }
+  });
+  // Invalidate size after the current frame to fix hidden container sizing
+  setTimeout(() => { try { _weatherMap.invalidateSize(false); } catch(e){} }, 50);
+}
+function updateMapView(lat, lon, cityLabel) {
+  try {
+    initLeafletMap();
+    if (!_weatherMap) return;
+    const target = [lat, lon];
+    if (!_weatherMapMarker) {
+      _weatherMapMarker = L.marker(target).addTo(_weatherMap);
+    } else {
+      _weatherMapMarker.setLatLng(target);
+    }
+    const zoomLevel = 13;
+    _weatherMap.flyTo(target, zoomLevel, { duration: 1.15 });
+    const labelEl = document.getElementById('map-city-label');
+    if (labelEl) labelEl.textContent = cityLabel || '';
+  } catch (e) {
+    console.error('Map update error:', e);
+  }
+}
+
 const AirQuality = (city) => {
   fetchAirQuality(city)
     .then((aqi) => updateAirQuality(aqi))
@@ -442,6 +488,9 @@ let weather = {
 
     document.getElementById("city").innerText =
       `${translations[userLang].weatherIn} ` + name;
+
+    // Update interactive map view
+    updateMapView(lat, lon, name);
 
     document.getElementById(
       "icon"

--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <!-- Leaflet CSS -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
 </head>
 
 <body id="body">
@@ -118,6 +120,11 @@
                 </button>
                 <div class="voice-status" id="voice-status"></div>
 </div>
+              </div>
+              <!-- Interactive Map (Leaflet + Esri World Imagery) -->
+              <div class="map-box">
+                <div class="map-header" id="map-city-label"></div>
+                <div id="weather-map"></div>
               </div>
               <div id="weather" class="weather-component__data loading">
                 <h1 id="city" class="weather-component__city-name fw-bold">___</h1>
@@ -442,6 +449,8 @@
     integrity="sha512-qTXRIMyZIFb8iQcfjXWCO8+M5Tbc38Qi5WzdPOYZHIlZpzBHG3L3by84BBBOiRGiEb7KKtAOAs5qYdUiZiQNNQ=="
     crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
+  <!-- Leaflet JS -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script type="module" src="./assets/js/script.js"></script>
 
 </body>


### PR DESCRIPTION
# Weather App - Map Integration

A small enhancement to the existing weather-app that adds an interactive map panel (Leaflet + Esri World Imagery) below the search input and adjusts the main weather card layout to match the design. Backend and existing weather logic remain unchanged — the map consumes coordinates returned by OpenWeather (`data.coord.lat` / `data.coord.lon`).

---

## ➕ Changes Introduced

- **Interactive map**
  - Added a Leaflet map with Esri World Imagery (satellite) tiles.
  - Map auto-centers and smoothly flies to an approximate zoom level (~13) and drops a marker for the searched or geolocated city.
  - A single Leaflet map instance is created once and reused for subsequent searches (no reinitialization on every search).
  - Fallback Esri tile endpoint is configured for tile load errors.

- **UI / layout**
  - Updated the main weather card layout to match the design.
  - Responsive `max-width` ~840px for the card.
  - Map height ~360px on desktop; responsive adjustments for mobile.
  - Leaflet default attribution is hidden by default to keep the card clean (can be re-enabled if explicit attribution is required).

- **No backend changes**
  - Existing weather API calls and backend logic remain unchanged.
  - The map reads coordinates already returned by OpenWeather (`data.coord.lat`, `data.coord.lon`).

---

## Map Implementation Details

- **Libraries used**
  - Leaflet (CSS + JS)
  - Esri World Imagery tiles for satellite basemap

- **Behavior**
  - On first load, the map is initialized via `initLeafletMap()`.
  - When `displayWeather()` receives coordinates, it calls `updateMapView(lat, lon, label)` which:
    - smooth-flies to the location at zoom ~13,
    - sets/updates a marker,
    - keeps the same map instance for future updates.

- **Robustness**
  - Tile error handler switches to a fallback Esri endpoint if the primary host fails.

---

## Files touched (UI only)

- `index.html`
  - Added Leaflet CSS/JS includes and the map container element.

- `assets/js/script.js`
  - Added `initLeafletMap()` and `updateMapView(lat, lon, label)`.
  - Calls `updateMapView` inside `displayWeather()` so weather results drive the map.

- `assets/css/styles.css`
  - Map styles and updated card width / responsive rules.

---

## 📄 Note to Reviewers

### How to run locally
From the project folder (`weather-app/`) run a simple HTTP server and open the app in your browser:

```bash
# from weather-app/:
py -m http.server 5500
# then open:
# http://localhost:5500/

# if served from the parent directory:
# http://localhost:5500/weather-app/
```


---

### 📷 Demo Video
https://github.com/user-attachments/assets/2fed3d10-aac7-4be8-bd4e-b96fc4e2a7b0

### 🖼️ Screenshot
<img width="700" alt="App Screenshot" src="https://github.com/user-attachments/assets/ff3bccfa-f2d9-48c3-871d-05c0f775f4ce" />


---