### PR TITLE
fixed conversion of temperature

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -637,7 +637,7 @@ function generateWeatherItem(
   let dayTemp = document.createElement("div");
   dayTemp.classList.add("weather-forecast-day");
   if (!isCelcius) {
-    dayTemperature = dayTemperature * (9 / 5) + 35;
+    dayTemperature = dayTemperature * (9 / 5) + 32;
     dayTemperature = (Math.round(dayTemperature * 100) / 100).toFixed(2);
     dayTemp.innerHTML = `${translations[userLang].day} ${dayTemperature}&#176;F`;
   } else {
@@ -649,7 +649,7 @@ function generateWeatherItem(
 
   let nightTemp = document.createElement("div");
   if (!isCelcius) {
-    nightTemperature = nightTemperature * (9 / 5) + 35;
+    nightTemperature = nightTemperature * (9 / 5) + 32;
     nightTemperature = (Math.round(nightTemperature * 100) / 100).toFixed(2);
     nightTemp.innerHTML = `${translations[userLang].night} ${nightTemperature}&#176;F`;
   } else {


### PR DESCRIPTION
### 🛠️ Fixes Issue
Closes #381

### ➕ Changes Introduced
- **Fixed incorrect Celsius to Fahrenheit conversion formula** in `generateWeatherItem()` function
- **Changed conversion constant from `+35` to `+32`** in both day and night temperature calculations
- **Resolves 3°F temperature offset** that was affecting all forecast temperatures in Fahrenheit mode
- **Updated lines 642 and 653** in `weather-app/assets/js/script.js`

**Technical Changes:**
```javascript
// Before (Incorrect)
dayTemperature = dayTemperature * (9 / 5) + 35;
nightTemperature = nightTemperature * (9 / 5) + 35;

// After (Fixed)
dayTemperature = dayTemperature * (9 / 5) + 32;
nightTemperature = nightTemperature * (9 / 5) + 32;
