### PR TITLE
Fix: Improve visibility of High Humidity alert text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -99,7 +99,8 @@ body {
 
 .alert-message {
   font-size: 12px;
-  color: #666;
+  color: #ffffff;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
   line-height: 1.4;
 }
 


### PR DESCRIPTION
Description:

This PR improves the contrast of the alert text in the “High Humidity” card for better readability across all themes and screens.
Fixes #434 
Screenshots:
Before:
<img width="343" height="91" alt="image" src="https://github.com/user-attachments/assets/1a73f188-1e93-4a0b-a171-3d46770d9647" />
After:
<img width="346" height="96" alt="image" src="https://github.com/user-attachments/assets/8e1adb8a-0c2d-43aa-bde5-a0a65c5203d0" />

